### PR TITLE
Remove incompatible warnings with Windows

### DIFF
--- a/ruy/BUILD
+++ b/ruy/BUILD
@@ -297,10 +297,14 @@ cc_library(
     hdrs = [
         "cpuinfo.h",
     ],
-    copts = ruy_copts() + [
-        # ruy_copts contains -Wundef, but cpuinfo's header warns with that.
-        "-Wno-undef",
-    ],
+    copts = ruy_copts() +
+        select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            # ruy_copts contains -Wundef, but cpuinfo's header warns with that.
+            "-Wno-undef",
+        ],
+    }),
     deps = [":platform"] + select({
         # cpuinfo does not build on ppc.
         ":ppc": [],

--- a/ruy/build_defs.bzl
+++ b/ruy/build_defs.bzl
@@ -3,16 +3,15 @@
 # Helper for ruy_copts().
 # Returns warnings flags to use for all ruy code.
 def ruy_copts_warnings():
-    return [
-        # TensorFlow is C++14 at the moment.
-        "-Wc++14-compat",
-        # Warn on preprocessor expansion of an undefined token, e.g. catching typos
-        # such as `#ifdef __linus__` instead of `#ifdef __linux__`.
-        "-Wundef",
-    ] + select({
+    return select({
         # We run into trouble on some Windows clang toolchains with -Wextra.
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
+            # TensorFlow is C++14 at the moment.
+            "-Wc++14-compat",
+            # Warn on preprocessor expansion of an undefined token, e.g. catching typos
+            # such as `#ifdef __linus__` instead of `#ifdef __linux__`.
+            "-Wundef",
             "-Wall",
             "-Wextra",
         ],


### PR DESCRIPTION
Remove failing options to MSVC.
Not clear if "-Wno-undef" and "-Wundef" could be remove, so I have let it there...