### PR TITLE
Fix the opensource build. Remove the :windows config_setting. It did not work because the bazel implementation using @bazel_tools//src/conditions was wrongly assuming that that was a flag_value that could be used in a config_setting, which it's not.

### DIFF
--- a/ruy/BUILD
+++ b/ruy/BUILD
@@ -32,11 +32,6 @@ config_setting(
 )
 
 config_setting(
-    name = "windows",
-    flag_values = {"//tools/cpp:cc_target_os": "windows"},
-)
-
-config_setting(
     name = "optimized",
     values = {
         "compilation_mode": "opt",
@@ -304,7 +299,7 @@ cc_library(
     ],
     copts = ruy_copts() +
             select({
-                ":windows": [],
+                "@bazel_tools//src/conditions:windows": [],
                 "//conditions:default": [
                     # ruy_copts contains -Wundef, but cpuinfo's header warns with that.
                     "-Wno-undef",
@@ -953,7 +948,7 @@ cc_library(
     # need defines, not copts, because it's controlling a header, test.h
     defines = ruy_test_ext_defines(),
     linkopts = select({
-        ":windows": [],
+        "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lm"],
     }),
     deps = [

--- a/ruy/build_defs.bzl
+++ b/ruy/build_defs.bzl
@@ -4,7 +4,7 @@
 # Returns warnings flags to use for all ruy code.
 def ruy_copts_warnings():
     return select({
-        "//ruy:windows": [
+        "@bazel_tools//src/conditions:windows": [
             # We run into trouble on Windows toolchains with warning flags,
             # as mentioned in the comments below on each flag.
             # We could be more aggressive in enabling supported warnings on each


### PR DESCRIPTION
Fix the opensource build. Remove the :windows config_setting. It did not work because the bazel implementation using @bazel_tools//src/conditions was wrongly assuming that that was a flag_value that could be used in a config_setting, which it's not.
