### PR TITLE
Corrected macro for detecting ppc platform.

### DIFF
--- a/ruy/platform.h
+++ b/ruy/platform.h
@@ -33,7 +33,7 @@ limitations under the License.
 #endif
 
 // Detect APPLE.
-#ifdef __ppc__
+#if defined(__ppc__) || defined(__powerpc__)
 #define RUY_PLATFORM_PPC 1
 #else
 #define RUY_PLATFORM_PPC 0


### PR DESCRIPTION
This macro `__powerpc__` is needed to detect ppc platform correctly. Otherwise the ruy build fails as it tries to compile cpuinfo which is known to not work on Power. And overall this fails the latest tensorflow build on Power.