### PR TITLE
Consistenly avoid include path stripping to remove some of the dimensions in debugging build errors with TensorFlow Makefiles.

### DIFF
--- a/ruy/BUILD
+++ b/ruy/BUILD
@@ -340,7 +340,7 @@ cc_library(
     ] + select({
         ":ppc": [],
         ":fuchsia": [],
-        "//conditions:default": ["@cpuinfo"],
+        "//conditions:default": ["@cpuinfo//:cpuinfo_with_unstripped_include_path"],
     }),
 )
 

--- a/ruy/cpuinfo.cc
+++ b/ruy/cpuinfo.cc
@@ -11,7 +11,7 @@
 #define RUY_HAVE_CPUINFO (!(RUY_PLATFORM_PPC || RUY_PLATFORM_FUCHSIA))
 
 #if RUY_HAVE_CPUINFO
-#include <cpuinfo.h>
+#include "include/cpuinfo.h"
 #endif
 
 namespace ruy {

--- a/third_party/cpuinfo.BUILD
+++ b/third_party/cpuinfo.BUILD
@@ -161,6 +161,16 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "cpuinfo_with_unstripped_include_path",
+    hdrs = [
+        "include/cpuinfo.h",
+    ],
+    deps = [
+        ":cpuinfo_impl",
+    ],
+)
+
 ############################# Build configurations #############################
 
 config_setting(


### PR DESCRIPTION
Consistenly avoid include path stripping to remove some of the dimensions in debugging build errors with TensorFlow Makefiles.
