### PR TITLE
Include cstring

### DIFF
--- a/ruy/kernel_x86.h
+++ b/ruy/kernel_x86.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define RUY_RUY_KERNEL_X86_H_
 
 #include <cstdint>
+#include <cstring>
 
 #include "ruy/kernel_common.h"
 #include "ruy/mat.h"


### PR DESCRIPTION
Failed to build ruy with bazel3.1 and GCC9.3.1 with below command:
```
bazel --output_user_root=$build_dir build -c dbg --copt=-march=native //ruy:ruy
```
Fix it if  Include cstring in kernel_x86.h