### PR TITLE
Change the default MulParams multiplier values to multiply by 1, not 0.

### DIFF
--- a/ruy/apply_multiplier.cc
+++ b/ruy/apply_multiplier.cc
@@ -24,6 +24,10 @@ namespace ruy {
 namespace detail {
 namespace {
 
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// Warning: this code is not meant to be bit-exact-normative.
+// Please refer to the class comment of ruy::MulParams, in mul_params.h.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // Copied from gemmlowp/fixedpoint.
 // Similar to the ARM64 instruction, SQRDMULH. The name of this function
 // is copied from the name of that instruction.
@@ -43,6 +47,10 @@ std::int32_t SaturatingRoundingDoublingHighMul(std::int32_t a, std::int32_t b) {
   return overflow ? std::numeric_limits<std::int32_t>::max() : ab_x2_high32;
 }
 
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// Warning: this code is not meant to be bit-exact-normative.
+// Please refer to the class comment of ruy::MulParams, in mul_params.h.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // Returns numerator/2^exponent, rounding to nearest, breaking ties
 // upwards. That particular tie-breaking behavior is not important in practice.
 // It happens to be cheap to implement in hardware and therefore, commonplace.
@@ -71,6 +79,10 @@ std::int32_t RoundingRightShift(std::int32_t numerator, int exponent) {
 
 }  // namespace
 
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// Warning: this code is not meant to be bit-exact-normative.
+// Please refer to the class comment of ruy::MulParams, in mul_params.h.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // Copied from TF Lite code.
 std::int32_t MultiplyByQuantizedMultiplier(std::int32_t x,
                                            std::int32_t quantized_multiplier,

--- a/ruy/apply_multiplier.h
+++ b/ruy/apply_multiplier.h
@@ -14,6 +14,10 @@ limitations under the License.
 ==============================================================================*/
 
 // Provides a reference (portable, non-optimized) ApplyMultiplier function.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// Warning: this code is not meant to be bit-exact-normative.
+// Please refer to the class comment of ruy::MulParams, in mul_params.h.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #ifndef RUY_RUY_APPLY_MULTIPLIER_H_
 #define RUY_RUY_APPLY_MULTIPLIER_H_

--- a/ruy/apply_multiplier_test.cc
+++ b/ruy/apply_multiplier_test.cc
@@ -107,9 +107,14 @@ void TestApplyMultiplier(const MulParams<AccumScalar, DstScalar>& mul_params,
 
 TEST(ApplyMultiplierTest, ApplyMultiplierUniform) {
   MulParams<std::int32_t, std::int8_t> mul_params;
+  // Test that default values give a multiplication by 1.
+  TestApplyMultiplier(mul_params, 0, 1000, 1000);
   mul_params.set_multiplier_fixedpoint(1 << 30);
   mul_params.set_multiplier_exponent(-1);
   TestApplyMultiplier(mul_params, 0, 1000, 250);
+  mul_params.set_multiplier_fixedpoint(1 << 25);
+  mul_params.set_multiplier_exponent(3);
+  TestApplyMultiplier(mul_params, 0, 1000, 125);
 }
 
 TEST(ApplyMultiplierTest, ApplyMultiplierPerChannel) {

--- a/ruy/mul_params.h
+++ b/ruy/mul_params.h
@@ -109,7 +109,7 @@ class MulParams final {
   // The bias vector data, if not null.
   const AccumScalar* bias() const { return storage_.bias; }
   void set_bias(const AccumScalar* ptr) { storage_.bias = ptr; }
-  // Only for non-floating-point cases. The fixed-point part  of the multiplier
+  // Only for non-floating-point cases. The fixed-point part of the multiplier
   // by which accumulators are multiplied before being casted to the destination
   // type. This is a fixed-point quantity with 0 integer bits. Since
   // (as explained in the class comment) AccumScalar must be std::int32_t,

--- a/ruy/mul_params_test.cc
+++ b/ruy/mul_params_test.cc
@@ -31,8 +31,8 @@ TEST(MulParamsTest, SpecClassSanity) {
 
   MulParamsType mul_params;
   EXPECT_EQ(mul_params.bias(), nullptr);
-  EXPECT_EQ(mul_params.multiplier_fixedpoint(), 1 << 30);
-  EXPECT_EQ(mul_params.multiplier_exponent(), 1);
+  EXPECT_EQ(mul_params.multiplier_fixedpoint(), std::numeric_limits<std::int32_t>::max());
+  EXPECT_EQ(mul_params.multiplier_exponent(), 0);
   EXPECT_EQ(mul_params.multiplier_fixedpoint_perchannel(), nullptr);
   EXPECT_EQ(mul_params.multiplier_exponent_perchannel(), nullptr);
   EXPECT_EQ(mul_params.clamp_min(), -128);

--- a/ruy/mul_params_test.cc
+++ b/ruy/mul_params_test.cc
@@ -31,8 +31,8 @@ TEST(MulParamsTest, SpecClassSanity) {
 
   MulParamsType mul_params;
   EXPECT_EQ(mul_params.bias(), nullptr);
-  EXPECT_EQ(mul_params.multiplier_fixedpoint(), 0);
-  EXPECT_EQ(mul_params.multiplier_exponent(), 0);
+  EXPECT_EQ(mul_params.multiplier_fixedpoint(), 1 << 30);
+  EXPECT_EQ(mul_params.multiplier_exponent(), 1);
   EXPECT_EQ(mul_params.multiplier_fixedpoint_perchannel(), nullptr);
   EXPECT_EQ(mul_params.multiplier_exponent_perchannel(), nullptr);
   EXPECT_EQ(mul_params.clamp_min(), -128);

--- a/ruy/ruy.h
+++ b/ruy/ruy.h
@@ -93,6 +93,14 @@ void Mul(const Matrix<LhsScalar>& lhs, const Matrix<RhsScalar>& rhs,
 // (e.g. the number of CPU cores in typical scenarios). At least ruy forces
 // each invocation to make an explicit decision here, there is no automatic
 // detection of the best number of threads to use in ruy.
+//
+// Constraints on the template parameters:
+// * If DstScalar is floating-point then AccumScalar must also be.
+// * If DstScalar is integral then AccumScalar must be std::int32_t.
+// Please refer to MulParams' class comment for more information. When
+// DstScalar is integral and is narrower than AccumScalar, additional
+// MulParams fields must be set to control the scaling of internal accumulators
+// before the final saturating cast to the DstScalar type.
 template <typename LhsScalar, typename RhsScalar, typename AccumScalar,
           typename DstScalar>
 void Mul(const Matrix<LhsScalar>& lhs, const Matrix<RhsScalar>& rhs,


### PR DESCRIPTION
Multiplying by 0 by default is unfriendly to people getting familiar
with ruy having to debug why their output values are all 0.
With a default of 1, tiny toy examples might output sane values,
anything beyond that will saturate, and seeing all saturated values will
be a hint that something needs to be set to rescale values.