### PR TITLE
limits include added

### DIFF
--- a/ruy/block_map.cc
+++ b/ruy/block_map.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 #ifdef RUY_MAKEBLOCKMAP_DEBUG
 #include <cstdio>


### PR DESCRIPTION
Added <limits> std include to fix build errors, e.g. https://github.com/tensorflow/tensorflow/issues/35626