### PR TITLE
Fix error when compiling ruy_test_overflow_dst_zero_point with GCC

### DIFF
--- a/ruy/test_overflow_dst_zero_point.cc
+++ b/ruy/test_overflow_dst_zero_point.cc
@@ -58,7 +58,7 @@ void TestOverflowingAdditionOfDestinationZeroPoint(ruy::Context* context,
                                      ? std::numeric_limits<DstScalar>::max()
                                      : std::numeric_limits<DstScalar>::min();
 
-  const std::vector<const std::int8_t> lhs_data(1, 0);
+  const std::vector<std::int8_t> lhs_data(1, 0);
   const std::vector<std::int8_t> rhs_data(cols, 0);
   std::vector<DstScalar> dst_data(cols, 0);
 


### PR DESCRIPTION
This fixes the following compilation error:

```
In file included from /usr/include/c++/10/vector:67,
                 from /home/keichi/Projects/ruy/ruy/test_overflow_dst_zero_point.cc:32:
/usr/include/c++/10/bits/stl_vector.h: In instantiation of ‘class std::vector<const signed char>’:
/home/keichi/Projects/ruy/ruy/test_overflow_dst_zero_point.cc:75:24:   required from here
/usr/include/c++/10/bits/stl_vector.h:401:66: error: static assertion failed: std::vector must have a non-const, non-volatile value_type
  401 |       static_assert(is_same<typename remove_cv<_Tp>::type, _Tp>::value,
      |                                                                  ^~~~~
```