### PR TITLE
Define namespace prefixed aliases for targets in the CMake build

### DIFF
--- a/cmake/ruy_cc_library.cmake
+++ b/cmake/ruy_cc_library.cmake
@@ -83,6 +83,8 @@ function(ruy_cc_library)
     )
   endif()
 
+  add_library(${PROJECT_NAME}::${_NAME} ALIAS ${_NAME})
+
   if(NOT _RULE_TESTONLY)
     install(
       TARGETS ${_NAME}


### PR DESCRIPTION
This allows projects that depend on ruy to use namespace qualified
target names regardless of whether they consume ruy through
add_subdirectory or find_package.