### PR TITLE
Reapply IWYU fix for std::string usage in instrumentation.h

### DIFF
--- a/ruy/profiler/instrumentation.h
+++ b/ruy/profiler/instrumentation.h
@@ -19,6 +19,7 @@ limitations under the License.
 #ifdef RUY_PROFILER
 #include <cstdio>
 #include <mutex>
+#include <string>
 #include <vector>
 #endif
 


### PR DESCRIPTION
The fix applied by Stephan Hartmann adding the missing include for std::string usage in libruy has been removed again after syncing again with the copybara service.

Bug: chromium:41455655