### PR TITLE
Fix signed integer overflow in MakeKernelParams8bit

### DIFF
--- a/ruy/kernel_common.h
+++ b/ruy/kernel_common.h
@@ -130,11 +130,12 @@ struct KernelParams8bit {
 };
 
 template <typename RhsScalar, typename DstScalar, int LhsCols, int RhsCols>
-RUY_NO_SANITIZE_INTEGER_OVERFLOW void MakeKernelParams8bit(
-    const PMat<std::int8_t> &lhs, const PMat<RhsScalar> &rhs,
-    const MulParams<std::int32_t, DstScalar> &mul_params, int start_row,
-    int start_col, int end_row, int end_col, Mat<DstScalar> *dst,
-    KernelParams8bit<LhsCols, RhsCols> *params) {
+void MakeKernelParams8bit(const PMat<std::int8_t>& lhs,
+                          const PMat<RhsScalar>& rhs,
+                          const MulParams<std::int32_t, DstScalar>& mul_params,
+                          int start_row, int start_col, int end_row,
+                          int end_col, Mat<DstScalar>* dst,
+                          KernelParams8bit<LhsCols, RhsCols>* params) {
   using Params = KernelParams8bit<LhsCols, RhsCols>;
 
   static_assert(sizeof(DstScalar) <= Params::kMaxDstTypeSize, "");
@@ -176,7 +177,13 @@ RUY_NO_SANITIZE_INTEGER_OVERFLOW void MakeKernelParams8bit(
   params->rhs_zero_point = rhs.zero_point;
   params->dst_zero_point = dst->zero_point;
   params->depth = depth;
-  params->prod_zp_depth = lhs.zero_point * rhs.zero_point * depth;
+  // prod_zp_depth intentionally relies on two's-complement wraparound to match
+  // the wrapping arithmetic performed by the asm kernels. Compute it in unsigned
+  // so the overflow is well-defined.
+  params->prod_zp_depth = static_cast<std::int32_t>(
+      static_cast<std::uint32_t>(lhs.zero_point) *
+      static_cast<std::uint32_t>(rhs.zero_point) *
+      static_cast<std::uint32_t>(depth));
   params->flags |= RUY_ASM_FLAG_NEEDS_LEFT_SHIFT;
   if (mul_params.multiplier_fixedpoint_perchannel()) {
     // Temporary release-assert to debug some crashes in an application.

--- a/ruy/kernel_common.h
+++ b/ruy/kernel_common.h
@@ -130,12 +130,11 @@ struct KernelParams8bit {
 };
 
 template <typename RhsScalar, typename DstScalar, int LhsCols, int RhsCols>
-void MakeKernelParams8bit(const PMat<std::int8_t>& lhs,
-                          const PMat<RhsScalar>& rhs,
-                          const MulParams<std::int32_t, DstScalar>& mul_params,
-                          int start_row, int start_col, int end_row,
-                          int end_col, Mat<DstScalar>* dst,
-                          KernelParams8bit<LhsCols, RhsCols>* params) {
+RUY_NO_SANITIZE_INTEGER_OVERFLOW void MakeKernelParams8bit(
+    const PMat<std::int8_t> &lhs, const PMat<RhsScalar> &rhs,
+    const MulParams<std::int32_t, DstScalar> &mul_params, int start_row,
+    int start_col, int end_row, int end_col, Mat<DstScalar> *dst,
+    KernelParams8bit<LhsCols, RhsCols> *params) {
   using Params = KernelParams8bit<LhsCols, RhsCols>;
 
   static_assert(sizeof(DstScalar) <= Params::kMaxDstTypeSize, "");

--- a/ruy/platform.h
+++ b/ruy/platform.h
@@ -159,4 +159,18 @@ limitations under the License.
 #define RUY_PLATFORM_EMSCRIPTEN 0
 #endif
 
+// Disables UBSan's integer-overflow checks for an annotated function. Only use
+// this where the overflow merely yields a wrong numeric result and poses no
+// safety risk. Expands to nothing on compilers without the attribute.
+#if defined(__clang__) && defined(__has_attribute)
+#if __has_attribute(no_sanitize)
+#define RUY_NO_SANITIZE_INTEGER_OVERFLOW                  \
+    __attribute__((no_sanitize("signed-integer-overflow", \
+                               "unsigned-integer-overflow")))
+#endif
+#endif
+#ifndef RUY_NO_SANITIZE_INTEGER_OVERFLOW
+#define RUY_NO_SANITIZE_INTEGER_OVERFLOW
+#endif
+
 #endif  // RUY_RUY_PLATFORM_H_

--- a/ruy/platform.h
+++ b/ruy/platform.h
@@ -159,18 +159,4 @@ limitations under the License.
 #define RUY_PLATFORM_EMSCRIPTEN 0
 #endif
 
-// Disables UBSan's integer-overflow checks for an annotated function. Only use
-// this where the overflow merely yields a wrong numeric result and poses no
-// safety risk. Expands to nothing on compilers without the attribute.
-#if defined(__clang__) && defined(__has_attribute)
-#if __has_attribute(no_sanitize)
-#define RUY_NO_SANITIZE_INTEGER_OVERFLOW                  \
-    __attribute__((no_sanitize("signed-integer-overflow", \
-                               "unsigned-integer-overflow")))
-#endif
-#endif
-#ifndef RUY_NO_SANITIZE_INTEGER_OVERFLOW
-#define RUY_NO_SANITIZE_INTEGER_OVERFLOW
-#endif
-
 #endif  // RUY_RUY_PLATFORM_H_


### PR DESCRIPTION
Compute `prod_zp_depth` via `uint32_t` casts so the intended wraparound is well-defined rather than UB. Overflow checks on the surrounding offset/pointer computations are left untouched. 

See chromium issue: https://issues.chromium.org/issues/526978330 and https://issues.chromium.org/issues/520870343