### PR TITLE
prepacked_cache: fix byte-accounting for evicted float matrices

### DIFF
--- a/ruy/prepacked_cache.cc
+++ b/ruy/prepacked_cache.cc
@@ -121,7 +121,16 @@ void PrepackedCache::EjectOne() {
     }
   }
   const PEMat& packed_matrix = oldest->second.packed_matrix;
-  buffers_bytes_ -= DataBytes(packed_matrix) + SumsBytes(packed_matrix);
+  // Mirror the accounting done in AllocateBuffers: floating-point matrices do
+  // not allocate a `sums` buffer, so only their `data` bytes were ever added
+  // to buffers_bytes_. Unconditionally subtracting SumsBytes here would
+  // over-subtract for float matrices (whose sums_type still has nonzero size),
+  // letting buffers_bytes_ drift below the true usage and the cache overshoot
+  // its cap.
+  buffers_bytes_ -= DataBytes(packed_matrix);
+  if (!packed_matrix.sums_type.is_floating_point) {
+    buffers_bytes_ -= SumsBytes(packed_matrix);
+  }
   FreeBuffers(packed_matrix);
   cache_.erase(oldest);
 }


### PR DESCRIPTION
### Problem
`PrepackedCache` tracks total cached bytes in `buffers_bytes_` to enforce `max_buffers_bytes_`. Insertion and eviction account for the `sums` buffer asymmetrically for floating-point matrices, so the running total drifts.

### Root cause
`AllocateBuffers` (`prepacked_cache.cc:29-39`) allocates and counts a `sums` buffer only for non-floating-point matrices — a float matrix adds just `DataBytes` to `buffers_bytes_` (`Get`, line 100). But `EjectOne` (line 124) unconditionally subtracted `DataBytes + SumsBytes`.

A float matrix's `sums_type` still reports a nonzero element size: it is set to `Type::Create<SumsType>()` with `SumsType = Scalar` for floating-point scalars (`create_trmul_params.h:62-69`), i.e. `float` (size 4). So `SumsBytes = layout.cols * sums_type.size > 0` (`mat.h:436-439`) even though no `sums` buffer was allocated. Each float eviction therefore over-subtracts `cols * 4`, letting `buffers_bytes_` drift below true usage (possibly negative) so the cache silently overshoots its cap.

### Fix
Subtract `SumsBytes` only for non-floating-point matrices, mirroring `AllocateBuffers`.

### Verification
Pure accounting logic; reproduced with a standalone model of insert/evict (float matrix, data=1000, cols*4=256):
```
inserted (added to buffers_bytes_): 1000
after evict  buggy buffers_bytes_ = -256  (should be 0)  -> DRIFT/WRONG
after evict  fixed buffers_bytes_ = 0     (should be 0)  -> OK
```
The existing `prepacked_cache_test.cc` does not catch this: its dummy float PEMat leaves `sums_type` at the default (size 0), and no test evicts a float matrix. Happy to add a regression test that evicts a float matrix.
