### PR TITLE
Avoid int overflow in block_map heuristics for large matmuls

### DIFF
--- a/ruy/block_map.cc
+++ b/ruy/block_map.cc
@@ -136,9 +136,14 @@ BlockMapTraversalOrder GetTraversalOrder(
     int rhs_scalar_size, const CpuCacheParams& cpu_cache_params) {
   static constexpr bool kAnyFractal =
       RUY_OPT(FRACTAL_Z) | RUY_OPT(FRACTAL_U) | RUY_OPT(FRACTAL_HILBERT);
-  const int working_set_size =
-      (lhs_scalar_size * rows_after_rectangularness_division +
-       rhs_scalar_size * cols_after_rectangularness_division) *
+  // Promote to int64 before multiplying: for a large matmul this product
+  // (bytes touched) exceeds INT_MAX, and a plain int computation would
+  // overflow (UB) and wrap negative, wrongly selecting a linear traversal for
+  // a working set that does not fit in cache. Mirrors GetTentativeThreadCount
+  // in trmul.cc, which promotes the same rows*cols*depth product to int64.
+  const std::int64_t working_set_size =
+      (std::int64_t{lhs_scalar_size} * rows_after_rectangularness_division +
+       std::int64_t{rhs_scalar_size} * cols_after_rectangularness_division) *
       depth;
   if (kAnyFractal && (working_set_size > cpu_cache_params.local_cache_size)) {
     if (RUY_OPT(FRACTAL_HILBERT) &&
@@ -258,9 +263,13 @@ int GetCacheLocalityScore(int block_size_log2, int rows, int cols, int depth,
   }
   const int block_rows = std::min(1 << block_size_log2, rows);
   const int block_cols = std::min(1 << block_size_log2, cols);
-  const int total_read_bytes =
-      (lhs_scalar_size * block_rows + rhs_scalar_size * block_cols) * depth;
-  const int total_read_bytes_log2 = ceil_log2(total_read_bytes);
+  // Promote to int64 before multiplying to avoid signed overflow (UB) for a
+  // large depth; the result only feeds ceil_log2 below (see GetTraversalOrder).
+  const std::int64_t total_read_bytes =
+      (std::int64_t{lhs_scalar_size} * block_rows +
+       std::int64_t{rhs_scalar_size} * block_cols) *
+      depth;
+  const int total_read_bytes_log2 = static_cast<int>(ceil_log2(total_read_bytes));
   const int nonlocality_log2 =
       total_read_bytes_log2 - floor_log2(cpu_cache_params.local_cache_size);
   // The values here have been tuned on ARM Cortex-A55.


### PR DESCRIPTION
### Problem
Two heuristics in `block_map.cc` compute a product of matrix dimensions in 32-bit `int`, which overflows (signed-overflow UB) for large matmuls and corrupts the traversal-order / block-size decision.

### Details
**`GetTraversalOrder`** (`working_set_size`):
```cpp
const int working_set_size =
    (lhs_scalar_size * rows_after_rectangularness_division +
     rhs_scalar_size * cols_after_rectangularness_division) * depth;
```
All operands are `int`. For a square f32 matmul (`scalar_size = 4`, `rows = cols = depth = N`) this is `8·N²`, which reaches `INT_MAX + 1` at `N = 16384` (`8·16384² = 2³¹`); int8 overflows at `N ≥ 32769`, and it also overflows with moderate rows/cols and large depth. On wrap-to-negative, `working_set_size > cpu_cache_params.local_cache_size` is false, so a multi-GB working set is treated as cache-resident and a **linear** traversal is chosen instead of the fractal order that exists to accelerate exactly these large, cache-non-resident matmuls.

**`GetCacheLocalityScore`** (`total_read_bytes`) has the same 32-bit product (`block_rows`/`block_cols` are capped, but `depth` is not), which overflows for large `depth` and feeds a garbage `ceil_log2`, corrupting the block-size score.

`Validate()` checks only zero-points, not dimensions, so these `int` dims are unbounded from `ruy::Mul`.

### Fix
Promote the operands to `std::int64_t` before multiplying, in both functions. This mirrors the sibling `GetTentativeThreadCount` in `trmul.cc`, which already computes the analogous `rows·cols·depth` product in `int64` with the comment:
> Be defensive here by explicitly promoting operands to int64 to avoid the pitfall of `int64 result = x * y;` overflowing as x and y are still narrow.

The subsequent comparisons (against the `int` cache-size params) and `ceil_log2` (templated) then operate safely.

### Testing
No unit test: triggering the overflow requires multi-GB operands, impractical for a unit test (the sibling `int64` promotion likewise has no dedicated overflow test). The overflow is provable by arithmetic (`8·16384² = 2³¹`), and the fix is a defensive widening matching the established `trmul.cc` precedent.
